### PR TITLE
[FE-2673] Prepare demo script for handling DoesNotExist results.

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,6 +163,10 @@ async function receiveQuerylogs(regionGroupCreds) {
   } else if (result.state === "Failed") {
     log_red("Failed! Final response:");
     console.log(result);
+  } else if (result.state === "DoesNotExist") {
+    log_green("Complete! Final response:");
+    console.log(result);
+    log_yellow("No query logs exist for your query. As such, the final response is 'DoesNotExist' with no URL.");
   } else {
     log_yellow(`The logs have been requested but not yet received. If you requested
 logs for a time-range with no activity, currently the request freezes.

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ async function receiveQuerylogs(regionGroupCreds) {
   } else if (result.state === "DoesNotExist") {
     log_green("Complete! Final response:");
     console.log(result);
-    log_yellow("No query logs exist for your query. As such, the final response is 'DoesNotExist' with no URL.");
+    log_yellow("No query logs exist for your request. As such, the final response is 'DoesNotExist' with no URL.");
   } else {
     log_yellow(`The logs have been requested but not yet received. If you requested
 logs for a time-range with no activity, currently the request freezes.


### PR DESCRIPTION
# Problem

Currently working on patching the querylogs feature to return `DoesNotExist` as the final state of requests that map to an empty result set of querylogs.

In preparation, prepare the demo to properly handle this output.

Also note, for now the script will not be detecting this state (as some software needs to be deployed first). So for now, the request frozen message is still in place and will be presented to users.

# Testing

Received some querylogs via `npm run demo`.