### PR TITLE
End polling if DoesNotExist terminal state found

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ async function receiveQuerylogs(regionGroupCreds) {
         continue;
       }
       if (e.response?.status === 401) {
-        log_red("You've lost your session - another client may have logged in with these credentials; please run the demo again.");cos
+        log_red("You've lost your session - another client may have logged in with these credentials; please run the demo again.");
         process.exit(1);
       }
       logger.error(e.response?.data);
@@ -120,7 +120,7 @@ async function receiveQuerylogs(regionGroupCreds) {
     await new Promise((resolve) => setTimeout(resolve, 1000));
   } while (
     Date.now() < startTime + maxRuntimeMs &&
-    !["Complete", "Failed"].includes(result.state)
+    !["Complete", "Failed", "DoesNotExist"].includes(result.state)
   );
   if (result.state === "Complete") {
     log_green("Complete! Final response:");
@@ -168,9 +168,7 @@ async function receiveQuerylogs(regionGroupCreds) {
     console.log(result);
     log_yellow("No query logs exist for your request. As such, the final response is 'DoesNotExist' with no URL.");
   } else {
-    log_yellow(`The logs have been requested but not yet received. If you requested
-logs for a time-range with no activity, currently the request freezes.
-This is an open item we are actively working on fixing.`);
+    log_yellow(`The logs have been requested but not yet received. Please retry, or cut support an issue if you continue to see this.`);
     console.log(result);
   }
 }


### PR DESCRIPTION
# Problem

Polling was continuing even though state was terminal in DoesNotExist.

# Solution

Stop polling when DoesNotExist seen.

# Testing

Ran the demo:

```
✔ Pick a region group › classic
✔ Pick a date-time to begin receiving query logs, inclusive. › 2020-09-26 10:39:30
✔ Pick a date-time to stop receiving query logs, exclusive. › 2020-09-27 10:39:32
Using input {"startTime":"2020-09-26T17:39:30.506Z","endTime":"2020-09-27T17:39:32.031Z","regionGroup":"classic"}
{
  requestId: '343976468072628819',
  state: 'Pending',
  startTime: '2020-09-26T17:39:30.506Z',
  endTime: '2020-09-27T17:39:32.031Z',
  regionGroup: 'classic'
}
 Polling for results for 2 minutes 
 Complete! Final response: 
{
  requestId: '343976468072628819',
  state: 'DoesNotExist',
  startTime: '2020-09-26T17:39:30.506Z',
  endTime: '2020-09-27T17:39:32.031Z',
  regionGroup: 'classic'
}
No query logs exist for your request. As such, the final response is 'DoesNotExist' with no URL. 
✔ Receive more query logs? … no
 Thanks for trying out query logs! Please give us any and all feedback!
```