### PR TITLE
Example program for fetching query logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Setup
+
+1. Install dependencies: `npm install`
+
 # What is this?
 
 A demo application for receiving query logs from your preview account or production account.
@@ -7,11 +11,3 @@ It runs in two modes:
 1. **Demo Mode** `npm run demo` - a guided CLI that uses the username and password of your preview account to create a synthetic dashboard session enabling the program to receive logs. The CLI demo is intended to show you the core functionality offered.
 2. **Program Mode** - `npm run example-program` - uses an **Account Key** to call the Fauna's frontdoor service to requests logs for your production Fauna account. To use this, make an **Account Key** in the production Fauna account of your choice and run! Inspect the source code in `example-program.js` to tweak the inputs.
 
-# Setup
-
-1. Install dependencies: `npm install`
-2. Run the demo application: `npm run demo`
-
-The demo application walks you through requesting Fauna query logs.
-Once query logs are received, you have the option to download them
-locally for analysis.

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ A demo application for receiving query logs from your preview account or product
 It runs in two modes:
 
 1. **Demo Mode** `npm run demo` - a guided CLI that uses the username and password of your preview account to create a synthetic dashboard session enabling the program to receive logs. The CLI demo is intended to show you the core functionality offered.
-2. **Program Mode** - `npm run example-program` - uses an **Account Key** to call the Fauna's frontdoor service to requests logs for your production Fauna account. To use this, make an **Account Key** in the production Fauna account of your choice and run! Inspect the source code in `example-program.js` to tweak the inputs.
+2. **Program Mode** - `npm run example-program` - uses an **Account Key** to call the Fauna's frontdoor service to requests logs for your production Fauna account. To use this, make an **Account Key** in the production Fauna account of your choice, export it to your local environment with `export ACCOUNT_KEY=<your_key>` and run! Inspect the source code in `example-program.js` to tweak the inputs.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # What is this?
 
-A demo application for receiving query logs from your preview account.
+A demo application for receiving query logs from your preview account or production account.
 
-Presently it uses your username and password to create a synthetic dashboard session enabling the program to receive logs; however, when
-the product launches we will support the creation and usage of API tokens. This will enable programs to use API tokens, rather than synthetic
-dashboard sessions, to receive query logs.
+It runs in two modes:
 
-# How do I use it?
+1. **Demo Mode** `npm run demo` - a guided CLI that uses the username and password of your preview account to create a synthetic dashboard session enabling the program to receive logs. The CLI demo is intended to show you the core functionality offered.
+2. **Program Mode** - `npm run example-program` - uses an **Account Key** to call the Fauna's frontdoor service to requests logs for your production Fauna account. To use this, make an **Account Key** in the production Fauna account of your choice and run! Inspect the source code in `example-program.js` to tweak the inputs.
+
+# Setup
 
 1. Install dependencies: `npm install`
 2. Run the demo application: `npm run demo`

--- a/example-program.js
+++ b/example-program.js
@@ -41,6 +41,10 @@ async function getLogs() {
   await pollResults(querylogRequest, headers, "us-std");
 }
 
+if (process.env["ACCOUNT_KEY"] === undefined) {
+  logger.error("You must set ACCOUNT_KEY in your local environment to run this program!");
+  return;
+}
 
 async function pollResults(
   querylogRequest,

--- a/example-program.js
+++ b/example-program.js
@@ -1,5 +1,6 @@
 const axios = require('axios').default;
 const winston = require('winston');
+const lux = require("luxon");
 
 const frontdoorClient = axios.create({
   baseURL: "https://frontdoor.fauna.com",
@@ -30,11 +31,14 @@ const logger = winston.createLogger({
   ],
 });
 
+const today = lux.DateTime.now().toISO();
+const yesterday = lux.DateTime.now().minus(lux.Duration.fromISO("P1D")).toISO();
+
 async function getLogs() {
   const headers = { Authorization: `Bearer ${process.env["ACCOUNT_KEY"]}` };
   const { data: querylogRequest } = await frontdoorClient.post(
     "/api/v1/logs?type=query",
-    { region_group: "us-std", time_start: "2023-02-14T00:00:00Z", time_end: "2023-02-15T00:00:00Z"},
+    { region_group: "us-std", time_start: yesterday, time_end: today},
     { headers }
   );
   logger.info(querylogRequest);

--- a/example-program.js
+++ b/example-program.js
@@ -1,0 +1,68 @@
+const axios = require('axios').default;
+const winston = require('winston');
+
+const frontdoorClient = axios.create({
+  baseURL: "https://frontdoor.fauna.com",
+  timeout: 10000,
+});
+
+/**
+   This example program shows you how to use an Account Key to fetch
+   logs programmatically. You could extend such a program to act on any
+   region group or time-bad according to your input; and extend it further
+   to fetch the logs with the resulting presigned_url and then dump it into
+   your observability platform.
+
+   To use it set ACCOUNT_KEY environmental variable to an account key in
+   your Fauna account.
+*/
+const logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.json(),
+  defaultMeta: { service: 'querylogs-demo' },
+  transports: [
+    new winston.transports.Console({
+      level: "debug",
+      handleExceptions: true,
+      // enable json output, good to send to DD
+      format: winston.format.json(),
+    }),
+  ],
+});
+
+async function getLogs() {
+  const headers = { Authorization: `Bearer ${process.env["ACCOUNT_KEY"]}` };
+  const { data: querylogRequest } = await frontdoorClient.post(
+    "/api/v1/logs?type=query",
+    { region_group: "us-std", time_start: "2023-02-14T00:00:00Z", time_end: "2023-02-15T00:00:00Z"},
+    { headers }
+  );
+  logger.info(querylogRequest);
+  await pollResults(querylogRequest, headers, "us-std");
+}
+
+
+async function pollResults(
+  querylogRequest,
+  headers,
+  region_group,
+) {
+  let result;
+  const maxRuntimeMs = 300 * 1000;
+  const time_start = Date.now();
+  do {
+    ({ data: result } = await frontdoorClient.get(
+      `/api/v1/logs/${querylogRequest.request_id}?regionGroup=${region_group}&type=query`,
+      { headers }
+    ));
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    logger.info(`State: ${result.state}`);
+  } while (
+    Date.now() < time_start + maxRuntimeMs &&
+    !["Complete", "DoesNotExist", "Failed", "TimedOut"].includes(result.state)
+  );
+  logger.info(result);
+  return result;
+}
+
+getLogs().then(() => logger.info("Thanks for trying out Fauna logs! Please give us any and all feedback!"));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Demo of using Fauna's querylog APIs.",
   "main": "index.js",
   "scripts": {
-    "demo": "node index.js"
+    "demo": "node index.js",
+    "example-program": "node example-program.js"
   },
   "author": "Fauna",
   "license": "ISC",


### PR DESCRIPTION
# Problem

No obvious demo of account key usage.

# Solution

Provide a dead simple program that uses an account key to fetch a query log.

# Testing

`npm run example-program`
